### PR TITLE
fix missing default date format

### DIFF
--- a/startup.lua
+++ b/startup.lua
@@ -66,6 +66,7 @@ local defaults = {
   -- tooltips
   disableTooltips = false,
   coloredTooltips = true,
+  dateFormat = "YYYY-MM-DD",
   hideKnowledge = false,
 
   hideBooks = true,


### PR DESCRIPTION
- hotfix: add missing default date format in settings

[//]: # "💀 LEAVE THIS LINE OR THE CHANGELOG MIGHT BREAK 💀"