### PR TITLE
translation generation, pathing, formatting

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -120,6 +120,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Increase versions, update changelog, prepare notes_$NEXT_VERSION.tmp for the PR body (empty notes are fine)
+      # Generate translation files and luaDoc
       # BODY looks like: "- describe your changes here\r\n- testchanges\r\n\r\n[//]: # \"\u2753 ..." (not JSON)
       - name: Update files
         id: update_files
@@ -132,20 +133,57 @@ jobs:
           TOADY="$(date --iso-8601)"
           python .scripts/furc_utils.py update_changelog --notes-file $NOTES_FILE --changelog-file "CHANGELOG" --header "$VERSION ($TOADY)"
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_OUTPUT
+
+          # Generate LuaDoc
+          LUADOC_DEFINITIONS="docs/autocomplete_definitions.lua"
+          LANGFILE_EN="locale/en.lua"
+          python .scripts/luaDoc_generateStr.py $LANGFILE_EN
+          python .scripts/luaDoc_generateGui.py xml/FurnitureCatalogue.xml $LUADOC_DEFINITIONS
+          python .scripts/luaDoc_generateGui.py FurnitureCatalogue_DevUtility/xml.xml $LUADOC_DEFINITIONS
+
+          # Generate translation files
+          for langfile in locale/*.lua; do
+            if [[ $langfile != $LANGFILE_EN ]]; then
+              python .scripts/luaDoc_generateStr.py $LANGFILE_EN $langfile --generate-translation
+            fi
+          done
         env:
           VERSION: ${{ steps.next_version.outputs.NEXT_VERSION }}
           NOTE: ${{ steps.get_details.outputs.BODY }}
+
+      # Format LUA files
+      - name: StyLUA Formatter
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: 4.0.0
+          args: --config-path=stylua.toml .
 
       # Commit version increments and CHANGELOG (if applicable)
       # Fails if empty commit
       - name: Commit Changelog
         run: |
+          # Add all files changed by furc_utils.py
           while read LINE ; do
             echo "Changed file: $LINE"
             git add $LINE
           done < $CHANGED_FILES
+          # Also add CHANGELOG, if it was changed
           git add 'CHANGELOG' || true
           git commit -m "Version bumps and CHANGELOG for $VERSION"
+
+          # Commit locale changes, if any
+          git add 'locale/*.lua' || true
+          git commit -m "Update translations for $VERSION" || true
+
+          # Commit luaDoc autocomplete changes, if any
+          git add ./docs/*.lua || true
+          git commit -m "Update luaDoc for $VERSION" || true
+
+          # Any remaining lua file changes must have been StyLUA
+          git add *.lua || true
+          git commit -m "Format LUA files with StyLUA" || true
+
           git push
           git reset --hard HEAD
           git clean -f -d

--- a/.scripts/luaDoc_generateGui.py
+++ b/.scripts/luaDoc_generateGui.py
@@ -2,19 +2,18 @@
 
 """Helps getting names of GUI elements for IDE support. Make a backup, if you have manual entries.
 
-Use inside the script folder and paths relative to the script, because those are being used as identifiers for the code section markers like:
+Use inside the project folder, because the relative paths are being used as identifiers for the code section markers like:
 
--- ////// START : GENERATED FROM ../FurnitureCatalogue_DevUtility/xml.xml
+-- ////// START : GENERATED FROM xml/FurnitureCatalogue.xml
 ...
--- ////// END   : GENERATED FROM ../FurnitureCatalogue_DevUtility/xml.xml
+-- ////// END   : GENERATED FROM xml/FurnitureCatalogue.xml
 
 Example calls:
-  cd .scripts
-  python ./luaDoc_generateGui.py
-  python ./luaDoc_generateGui.py ../dir/input.xml
-  python ./luaDoc_generateGui.py ../dir/input.xml ./output.lua
-  python ./luaDoc_generateGui.py ../xml/FurnitureCatalogue.xml
-  python ./luaDoc_generateGui.py ../FurnitureCatalogue_DevUtility/xml.xml
+  python .scripts/luaDoc_generateGui.py
+  python .scripts/luaDoc_generateGui.py dir/input.xml
+  python .scripts/luaDoc_generateGui.py dir/input.xml ./output.lua
+  python .scripts/luaDoc_generateGui.py xml/FurnitureCatalogue.xml
+  python .scripts/luaDoc_generateGui.py FurnitureCatalogue_DevUtility/xml.xml
 """
 
 import sys
@@ -46,7 +45,7 @@ def load_xml_file(path: str) -> ET.Element:
     root = tree.getroot()
   except Exception:
     print(f"File not found or invalid XML: {path}")
-    print(f"Please run from inside the script folder and use relative paths like ../dir/some.xml")
+    print(f"Please run from the base folder and use relative paths like dir/some.xml")
     exit(EXIT_FAILURE)
   return root
 
@@ -117,11 +116,11 @@ def write_lua_doc(identifier: str, lua_path: str, parsed: list):
 
 
 if __name__ == '__main__':
-  lua_path = "luaDoc_Definitions.lua"
+  lua_path = "docs/autocomple_definitions.lua"
 
   if len(sys.argv) == 1:
     # use default files if none supplied
-    xml_paths = ["../xml/FurnitureCatalogue.xml", "../FurnitureCatalogue_DevUtility/xml.xml"]
+    xml_paths = ["xml/FurnitureCatalogue.xml", "FurnitureCatalogue_DevUtility/xml.xml"]
     for xml_path in xml_paths:
       resolved_names = get_resolved_hierarchy(load_xml_file(xml_path))
       write_lua_doc(identifier=xml_path, lua_path=lua_path, parsed=resolved_names)

--- a/docs/autocomplete_definitions.lua
+++ b/docs/autocomplete_definitions.lua
@@ -19,7 +19,7 @@ It should not include:
 --]]
 --
 
--- ////// START : GENERATED FROM ../xml/FurnitureCatalogue.xml
+-- ////// START : GENERATED FROM xml/FurnitureCatalogue.xml
 ---------- LVL: 00 ----------
 ---------- LVL: 01 ----------
 ---------- LVL: 02 ----------
@@ -83,8 +83,8 @@ FurCGui_Header_SortBar_Quality_Button = ButtonControl
 ---------- LVL: 12 ----------
 FurC_SearchBoxBackdrop = BackdropControl
 ---------- LVL: 13 ----------
--- ////// END   : GENERATED FROM ../xml/FurnitureCatalogue.xml
--- ////// START : GENERATED FROM ../FurnitureCatalogue_DevUtility/xml.xml
+-- ////// END   : GENERATED FROM xml/FurnitureCatalogue.xml
+-- ////// START : GENERATED FROM FurnitureCatalogue_DevUtility/xml.xml
 ---------- LVL: 00 ----------
 ---------- LVL: 01 ----------
 ---------- LVL: 02 ----------
@@ -96,9 +96,9 @@ FurCDevControl_hide = ButtonControl
 FurCDevControl_clear = ButtonControl
 FurCDevControlBox = EditControl
 ---------- LVL: 05 ----------
--- ////// END   : GENERATED FROM ../FurnitureCatalogue_DevUtility/xml.xml
+-- ////// END   : GENERATED FROM FurnitureCatalogue_DevUtility/xml.xml
 
--- ////// START : GENERATED FROM ../locale/en.lua
+-- ////// START : GENERATED FROM locale/en.lua
 
 ------ PLACEHOLDERS ------
 local filterDisabled = "disables this filter"
@@ -411,7 +411,7 @@ SI_FURC_EVENT_BLACKWOOD = "From participating in the Bounties of Blackwood event
 SI_FURC_TRIBUTE = "From Tales of Tribute reward coffers"
 SI_FURC_TRIBUTE_RANKED = "From Tales of Tribute ranked matches (system mail reward)"
 SI_FURC_SEEN_IN_GUILDSTORE = "Seen in Guild Store"
--- ////// END   : GENERATED FROM ../locale/en.lua
+-- ////// END   : GENERATED FROM locale/en.lua
 
 -- ////// START   : Manual entries and overrides
 ---@class LibDebugLogger

--- a/locale/de.lua
+++ b/locale/de.lua
@@ -1,6 +1,6 @@
 local filterDisabled = "disables this filter"
 local strings = {
-
+  -- ////// START : DON'T REMOVE THIS LINE
   FURC_AV_RAZ = "Razoufa",
   FURC_AV_MUL = "Mulvise Valyn",
 
@@ -272,6 +272,7 @@ local strings = {
   SI_FURC_ITEMSOURCE_ITEMPACK = "Part of the Crown Store item pack [<<1>>] ",
 
   SI_FURC_SEEN_IN_GUILDSTORE = "Seen in Guild Store",
+  -- ////// END   : DON'T REMOVE THIS LINE
 }
 
 for stringId, stringValue in pairs(strings) do

--- a/locale/fr.lua
+++ b/locale/fr.lua
@@ -1,6 +1,6 @@
 local filterDisabled = "désactive ce filtre"
 local strings = {
-
+  -- ////// START : DON'T REMOVE THIS LINE
   FURC_AV_RAZ = "Razoufa",
   FURC_AV_MUL = "Mulvisë Valyn",
 
@@ -299,6 +299,7 @@ local strings = {
   SI_FURC_ITEMSOURCE_ITEMPACK = "Fait partie du pack d'objets de la Boutique à Couronnes [<<1>>] ",
 
   SI_FURC_SEEN_IN_GUILDSTORE = "Vu dans le magasin de guilde",
+  -- ////// END   : DON'T REMOVE THIS LINE
 }
 
 for stringId, stringValue in pairs(strings) do

--- a/locale/jp.lua
+++ b/locale/jp.lua
@@ -1,6 +1,6 @@
 local filterDisabled = "disables this filter"
 local strings = {
-
+  -- ////// START : DON'T REMOVE THIS LINE
   FURC_AV_RAZ = "Razoufa",
   FURC_AV_MUL = "Mulvise Valyn",
 
@@ -266,6 +266,7 @@ local strings = {
   SI_FURC_ITEMSOURCE_ITEMPACK = "Part of the Crown Store item pack [<<1>>] ",
 
   SI_FURC_SEEN_IN_GUILDSTORE = "Seen in Guild Store",
+  -- ////// END   : DON'T REMOVE THIS LINE
 }
 
 for stringId, stringValue in pairs(strings) do

--- a/locale/ru.lua
+++ b/locale/ru.lua
@@ -1,6 +1,6 @@
 local filterDisabled = "disables this filter"
 local strings = {
-
+  -- ////// START : DON'T REMOVE THIS LINE
   FURC_AV_RAZ = "Razoufa",
   FURC_AV_MUL = "Mulvise Valyn",
 
@@ -266,6 +266,7 @@ local strings = {
   SI_FURC_ITEMSOURCE_ITEMPACK = "Part of the Crown Store item pack [<<1>>] ",
 
   SI_FURC_SEEN_IN_GUILDSTORE = "Seen in Guild Store",
+  -- ////// END   : DON'T REMOVE THIS LINE
 }
 
 for stringId, stringValue in pairs(strings) do


### PR DESCRIPTION
Added some more tasks to the automated release:

1. automatically generate missing translation strings
2. format all code before release to ensure PRs and autogenerated code are always styled the same way (alternative to pre-commit)
3. generate luadoc definitions for IDE autocompletion