### PR TITLE
Gold Road, Formatting, and Localization

### DIFF
--- a/locale/en.lua
+++ b/locale/en.lua
@@ -35,7 +35,6 @@ local strings = {
   SI_FURC_FILTER_SRC_CRAFTING_TT = "Shows all craftable items",
   SI_FURC_FILTER_SRC_CRAFTING_UNKNOWN = "Craftable: Unknown",
   SI_FURC_FILTER_SRC_CRAFTING_UNKNOWN_TT = "Shows only unknown craftable items",
-=======
   SI_FURC_FILTER_SRC_CROWN = "Crown Store",
   SI_FURC_FILTER_SRC_CROWN_TT = "Shows items that can only be acquired from crown store",
   SI_FURC_FILTER_SRC_FAVE = "Favorites",


### PR DESCRIPTION
This update adds items from the Gold Road chapter, as well as changes some of the addon formatting and localization for smoother translations and viewing.

[//]: # "❓ YOU CAN DELETE THE TEXT IF THIS IS NOT AN IMMEDIATE RELEASE ❓"
[//]: # "⬆️⬆️⬆️ ABOVE WILL BE USED FOR LOCAL AND ESOUI CHANGELOG ⬆️⬆️⬆️"
[//]: # "💀 LEAVE THIS LINE OR THE CHANGELOG MIGHT BREAK 💀"
[//]: # "header like '1.23 (2023-12-12)' will be generated"
[//]: # "⬇️⬇️⬇️ STUFF BELOW WONT BE SENT TO ESOUI ⬇️⬇️⬇️"

## Checklist for automatic Release

- [x] 📑 I edited or deleted the **notes** for the changelogs
- [x] ⚠️ I left at least 1 invisible `[//]: # "comment block"` untouched
- [x] 🏷️ I labeled this PR `actions:RELEASE` (+optional version labels)

## About this Release

- optional details regarding this PR
- will not show up in changelog

## Related issues

- any related issues
