### PR TITLE
Gold Road, Formatting, and Localization updates

### DIFF
--- a/data/MiscItemSources.lua
+++ b/data/MiscItemSources.lua
@@ -91,7 +91,7 @@ local painting_summerset = strGeneric(srcSafe, rarityExtremely, "loc", loc.SUMME
 local painting_vvardenfell = strGeneric(
   srcDrop,
   string.format("%s, %s", strSrc("other", srcChest, srcSafe), rarityExtremely),
-  "loc"
+  "loc",
   loc.VVARDENFELL
 )
 


### PR DESCRIPTION
This update adds items from the Gold Road chapter, as well as changes some of the addon formatting and localization for smoother translations and viewing.

[//]: # "❓ YOU CAN DELETE THE TEXT IF THIS IS NOT AN IMMEDIATE RELEASE ❓"
[//]: # "⬆️⬆️⬆️ ABOVE WILL BE USED FOR LOCAL AND ESOUI CHANGELOG ⬆️⬆️⬆️"
[//]: # "💀 LEAVE THIS LINE OR THE CHANGELOG MIGHT BREAK 💀"
[//]: # "header like '1.23 (2023-12-12)' will be generated"
[//]: # "⬇️⬇️⬇️ STUFF BELOW WONT BE SENT TO ESOUI ⬇️⬇️⬇️"

## Checklist for automatic Release

- [ ] 📑 I edited or deleted the **notes** for the changelogs
- [ ] ⚠️ I left at least 1 invisible `[//]: # "comment block"` untouched
- [ ] 🏷️ I labeled this PR `actions:RELEASE` (+optional version labels)

## About this Release

Third time's the charm, right?

## Related issues

- any related issues
