### PR TITLE
Weald Pickpocket

### DIFF
--- a/data/LuxuryFurnisher.lua
+++ b/data/LuxuryFurnisher.lua
@@ -242,7 +242,7 @@ FurC.LuxuryFurnisher[ver.SCRIBE] = {
   },
   [193801] = { -- Ayleid Partition, Arched,
     itemPrice = 20000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [193800] = { -- Falmer Tent, Conical,
     itemPrice = 4000,
@@ -486,7 +486,7 @@ FurC.LuxuryFurnisher[ver.TIDES] = {
   },
   [182629] = { -- Ayleid Brazier, Stone
     itemPrice = 10000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [182628] = { -- Riekr Tent, Snowy
     itemPrice = 3500,
@@ -1758,7 +1758,7 @@ FurC.LuxuryFurnisher[ver.MARKAT] = {
   },
   [171421] = { -- Ayleid Pillar, Large Empty
     itemPrice = 14000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [171420] = { -- Riekling Rack, Giant Bone
     itemPrice = 3000,
@@ -1806,7 +1806,7 @@ FurC.LuxuryFurnisher[ver.MARKAT] = {
   },
   [156664] = { -- Ayleid Pillar, Small Empty
     itemPrice = 5000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [156663] = { -- Riekling Banner, Boar Pelt
     itemPrice = 4000,
@@ -2078,19 +2078,19 @@ FurC.LuxuryFurnisher[ver.SLAVES] = {
   },
   [134468] = { -- Ayleid Switch, Ancient
     itemPrice = 4000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [134467] = { -- Culanda Stone ,Glowing
     itemPrice = 5000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [134466] = { -- Ayleid Sconce, Empty
     itemPrice = 4000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [134465] = { -- Varla Stone ,Glowing
     itemPrice = 5000,
-    itemDate = "2023-05-13",
+    itemDate = "2024-06-07",
   },
   [134456] = { -- Seal of Clan Tumnosh, Metal
     itemPrice = 4000,

--- a/data/MiscItemSources.lua
+++ b/data/MiscItemSources.lua
@@ -87,6 +87,7 @@ local stealable_noble = strGeneric(srcPick, strSrc("other", npc.CLASS_NOBLE))
 local stealable_swamp = strGeneric(srcSteal, nil, "loc", loc.MURKMIRE)
 local stealable_elsewhere = strGeneric(srcSteal, nil, "other", loc.NELSWEYR, loc.SELSWEYR)
 local pickpocket_necrom = strGeneric(srcPick, nil, "other", loc.TELVANNI, loc.APOCRYPHA)
+local pickpocket_weald = strGeneric(srcPick, nil, "other", loc.WEALD)
 local painting_summerset = strGeneric(srcSafe, rarityExtremely, "loc", loc.SUMMERSET)
 local painting_vvardenfell = strGeneric(
   srcDrop,
@@ -202,18 +203,18 @@ FurC.MiscItemSources[ver.WEALD] = {
   },
   
   [src.DROP] = {
-	[204800] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Preparing to Entertain Painting, Wood",
-	[204801] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Great Chapel of Julianos Painting, Wood",
-	[204802] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Wonders of Water Painting, Wood",
-	[204803] = strGeneric(srcChest, nil, nil, loc.WEALD), -- An Alfiq in Skingrad Painting, Metal",
-	[204804] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Arch to Ayleid Mysteries Painting, Wood",
-	[204805] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Colovian Windmill Painting, Wood",
-	[204806] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Autumn on the Gold Road Painting, Wood",
-	[204807] = strGeneric(srcChest, nil, nil, loc.WEALD), -- A Clear Day in Colovia Painting, Metal",
-	[204808] = strGeneric(srcChest, nil, nil, loc.WEALD), -- West Weald Adventures Painting, Metal",
-	[204754] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Sun-Gilded Vineyard Painting, Metal",
-	[204755] = strGeneric(srcChest, nil, nil, loc.WEALD), -- Colovian Bounty Painting, Wood",
-	[204799] = strGeneric(srcChest, nil, nil, loc.WEALD), -- The Optimism of Dogs Painting, Metal",
+	[204800] = strChests(loc.WEALD), -- Preparing to Entertain Painting, Wood",
+	[204801] = strChests(loc.WEALD), -- Great Chapel of Julianos Painting, Wood",
+	[204802] = strChests(loc.WEALD), -- Wonders of Water Painting, Wood",
+	[204803] = strChests(loc.WEALD), -- An Alfiq in Skingrad Painting, Metal",
+	[204804] = strChests(loc.WEALD), -- Arch to Ayleid Mysteries Painting, Wood",
+	[204805] = strChests(loc.WEALD), -- Colovian Windmill Painting, Wood",
+	[204806] = strChests(loc.WEALD), -- Autumn on the Gold Road Painting, Wood",
+	[204807] = strChests(loc.WEALD), -- A Clear Day in Colovia Painting, Metal",
+	[204808] = strChests(loc.WEALD), -- West Weald Adventures Painting, Metal",
+	[204754] = strChests(loc.WEALD), -- Sun-Gilded Vineyard Painting, Metal",
+	[204755] = strChests(loc.WEALD), -- Colovian Bounty Painting, Wood",
+	[204799] = strChests(loc.WEALD), -- The Optimism of Dogs Painting, Metal",
 	
 	[204424] = strScry(loc.WEALD), -- Antique Map of West Weald",	
     [204423] = strScry(5, loc.WEALD), -- Music Box, Lament for the Path Not Taken",


### PR DESCRIPTION
Fixed item sourcing for West Weald pickpocket items and adjusted dates for this weekend's lux vendor items.

[//]: # "❓ YOU CAN DELETE THE TEXT IF THIS IS NOT AN IMMEDIATE RELEASE ❓"
[//]: # "⬆️⬆️⬆️ ABOVE WILL BE USED FOR LOCAL AND ESOUI CHANGELOG ⬆️⬆️⬆️"
[//]: # "💀 LEAVE THIS LINE OR THE CHANGELOG MIGHT BREAK 💀"
[//]: # "header like '1.23 (2023-12-12)' will be generated"
[//]: # "⬇️⬇️⬇️ STUFF BELOW WONT BE SENT TO ESOUI ⬇️⬇️⬇️"

## Checklist for automatic Release

- [ ] 📑 I edited or deleted the **notes** for the changelogs
- [ ] ⚠️ I left at least 1 invisible `[//]: # "comment block"` untouched
- [ ] 🏷️ I labeled this PR `actions:RELEASE` (+optional version labels)
